### PR TITLE
scheduler improvements

### DIFF
--- a/_examples/delayedTask.lua
+++ b/_examples/delayedTask.lua
@@ -1,6 +1,6 @@
 script.registerSimpleCommand(function(sender, args)
     sender:sendRichMessage("<green>Hello, "..sender:getName())
-    utils.scheduleSyncDelayedTask(function()
+    scheduler.runDelayed(function()
             sender:sendRichMessage("<yellow>This was sent 40 ticks later (2 seconds)! BukkitScheduler works!")
     end, 40)
 end, {

--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScheduler.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScheduler.kt
@@ -1,0 +1,170 @@
+package xyz.galaxyy.lualink.lua
+
+import com.github.only52607.luakt.CoerceKotlinToLua
+import org.bukkit.scheduler.BukkitRunnable
+import org.luaj.vm2.LuaTable
+import org.luaj.vm2.Varargs
+import org.luaj.vm2.lib.VarArgFunction
+import xyz.galaxyy.lualink.LuaLink
+
+class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) : LuaTable() {
+
+    init {
+
+        // schedules single task to be executed on the next tick
+        this.set("run", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 1) {
+                    throw IllegalArgumentException("run expects 1 argument: callback")
+                }
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                // scheduling new task
+                val task = object : BukkitRunnable() {
+                    override fun run() {
+                        callback.call()
+                    }
+                }.runTask(plugin)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+        // schedules single (asynchronous) task to be executed on the next tick
+        this.set("runAsync", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 1) {
+                    throw IllegalArgumentException("runAsync expects 1 argument: callback")
+                }
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                // scheduling new task
+                val task = object : BukkitRunnable() {
+                    override fun run() {
+                        callback.call()
+                    }
+                }.runTaskAsynchronously(plugin)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+        // schedules single task to be executed after n ticks has passed
+        this.set("runLater", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 2)
+                    throw IllegalArgumentException("runLater expects 2 arguments: callback, delay")
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                val delay = args.arg(2).checklong()
+                // scheduling new task
+                val task = if (callback.narg() == 1)
+                               // scheduling new task with callback returning this task instance
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call(CoerceKotlinToLua.coerce(this)) }
+                               }.runTaskLater(plugin, delay)
+                           else
+                               // scheduling new task with no-arg callback
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call() }
+                               }.runTaskLater(plugin, delay)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+        // schedules single (asynchronous) task to be executed after n ticks has passed
+        this.set("runLaterAsync", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 2)
+                    throw IllegalArgumentException("runLaterAsync expects 2 arguments: callback, delay")
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                val delay = args.arg(2).checklong()
+                // scheduling new task
+                val task = if (callback.narg() == 1)
+                               // scheduling new task with callback returning this task instance
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call(CoerceKotlinToLua.coerce(this)) }
+                               }.runTaskLaterAsynchronously(plugin, delay)
+                           else
+                               // scheduling new task with no-arg callback
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call() }
+                               }.runTaskLaterAsynchronously(plugin, delay)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+        // schedules repeating task to be started after n ticks has passed and repeated each m ticks
+        this.set("runTimer", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 3)
+                    throw IllegalArgumentException("runTimer expects 3 arguments: callback, delay, period")
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                val delay = args.arg(2).checklong()
+                val period = args.arg(3).checklong()
+                // scheduling new task
+                val task = if (callback.narg() == 1)
+                               // scheduling new task with callback returning this task instance
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call(CoerceKotlinToLua.coerce(this)) }
+                               }.runTaskTimer(plugin, delay, period)
+                           else
+                               // scheduling new task with no-arg callback
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call() }
+                               }.runTaskTimer(plugin, delay, period)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+        // schedules repeating (asynchronous) task to be started after n ticks has passed and repeated each m ticks
+        this.set("runTimerAsync", object: VarArgFunction() {
+            override fun invoke(args: Varargs?): Varargs {
+                // validating function call
+                if (args == null || args.narg() != 3)
+                    throw IllegalArgumentException("runTimerAsync expects 3 arguments: callback, delay, period")
+                // parsing function arguments
+                val callback = args.arg(1).checkfunction()
+                val delay = args.arg(2).checklong()
+                val period = args.arg(3).checklong()
+                // scheduling new task
+                val task = if (callback.narg() == 1)
+                               // scheduling new task with callback returning this task instance
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call(CoerceKotlinToLua.coerce(this)) }
+                               }.runTaskTimerAsynchronously(plugin, delay, period)
+                           else
+                               // scheduling new task with no-arg callback
+                               object : BukkitRunnable() {
+                                   override fun run() { callback.call() }
+                               }.runTaskTimerAsynchronously(plugin, delay, period)
+                // adding task id to the list
+                script.tasks.add(task.taskId)
+                // returning task
+                return CoerceKotlinToLua.coerce(task)
+            }
+        })
+
+    }
+
+}

--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScheduler.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScheduler.kt
@@ -3,12 +3,12 @@ package xyz.galaxyy.lualink.lua
 import com.github.only52607.luakt.CoerceKotlinToLua
 import org.bukkit.scheduler.BukkitRunnable
 import org.luaj.vm2.LuaTable
+import org.luaj.vm2.LuaValue
 import org.luaj.vm2.Varargs
 import org.luaj.vm2.lib.VarArgFunction
 import xyz.galaxyy.lualink.LuaLink
 
 class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) : LuaTable() {
-
     init {
 
         // schedules single task to be executed on the next tick
@@ -28,8 +28,8 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
                 }.runTask(plugin)
                 // adding task id to the list
                 script.tasks.add(task.taskId)
-                // returning task
-                return CoerceKotlinToLua.coerce(task)
+                // returning nil
+                return LuaValue.NIL
             }
         })
 
@@ -50,17 +50,17 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
                 }.runTaskAsynchronously(plugin)
                 // adding task id to the list
                 script.tasks.add(task.taskId)
-                // returning task
-                return CoerceKotlinToLua.coerce(task)
+                // returning nil
+                return LuaValue.NIL
             }
         })
 
         // schedules single task to be executed after n ticks has passed
-        this.set("runLater", object: VarArgFunction() {
+        this.set("runDelayed", object: VarArgFunction() {
             override fun invoke(args: Varargs?): Varargs {
                 // validating function call
                 if (args == null || args.narg() != 2)
-                    throw IllegalArgumentException("runLater expects 2 arguments: callback, delay")
+                    throw IllegalArgumentException("runDelayed expects 2 arguments: callback, delay")
                 // parsing function arguments
                 val callback = args.arg(1).checkfunction()
                 val delay = args.arg(2).checklong()
@@ -83,11 +83,11 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
         })
 
         // schedules single (asynchronous) task to be executed after n ticks has passed
-        this.set("runLaterAsync", object: VarArgFunction() {
+        this.set("runDelayedAsync", object: VarArgFunction() {
             override fun invoke(args: Varargs?): Varargs {
                 // validating function call
                 if (args == null || args.narg() != 2)
-                    throw IllegalArgumentException("runLaterAsync expects 2 arguments: callback, delay")
+                    throw IllegalArgumentException("runDelayedAsync expects 2 arguments: callback, delay")
                 // parsing function arguments
                 val callback = args.arg(1).checkfunction()
                 val delay = args.arg(2).checklong()
@@ -110,11 +110,11 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
         })
 
         // schedules repeating task to be started after n ticks has passed and repeated each m ticks
-        this.set("runTimer", object: VarArgFunction() {
+        this.set("runRepeating", object: VarArgFunction() {
             override fun invoke(args: Varargs?): Varargs {
                 // validating function call
                 if (args == null || args.narg() != 3)
-                    throw IllegalArgumentException("runTimer expects 3 arguments: callback, delay, period")
+                    throw IllegalArgumentException("runRepeating expects 3 arguments: callback, delay, period")
                 // parsing function arguments
                 val callback = args.arg(1).checkfunction()
                 val delay = args.arg(2).checklong()
@@ -138,11 +138,11 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
         })
 
         // schedules repeating (asynchronous) task to be started after n ticks has passed and repeated each m ticks
-        this.set("runTimerAsync", object: VarArgFunction() {
+        this.set("runRepeatingAsync", object: VarArgFunction() {
             override fun invoke(args: Varargs?): Varargs {
                 // validating function call
                 if (args == null || args.narg() != 3)
-                    throw IllegalArgumentException("runTimerAsync expects 3 arguments: callback, delay, period")
+                    throw IllegalArgumentException("runRepeatingAsync expects 3 arguments: callback, delay, period")
                 // parsing function arguments
                 val callback = args.arg(1).checkfunction()
                 val delay = args.arg(2).checklong()
@@ -166,5 +166,4 @@ class LuaScheduler(private val plugin: LuaLink, private val script: LuaScript) :
         })
 
     }
-
 }

--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScriptManager.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScriptManager.kt
@@ -26,6 +26,7 @@ class LuaScriptManager(private val plugin: LuaLink) {
         globals.set("script", script)
         globals.set("print", PrintOverride(this.plugin))
         globals.set("utils", LuaUtils(this.plugin, script)) // Passing script to LuaUtils for state
+        globals.set("scheduler", LuaScheduler(this.plugin, script)) // Passing script to LuaScheduler for state
         globals.set("enums", LuaEnumWrapper())
         globals.set("import", LuaImport())
         globals.set("addons", LuaAddons())

--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScriptManager.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScriptManager.kt
@@ -25,7 +25,7 @@ class LuaScriptManager(private val plugin: LuaLink) {
         globals.load(LuaKotlinExLib())
         globals.set("script", script)
         globals.set("print", PrintOverride(this.plugin))
-        globals.set("utils", LuaUtils(this.plugin, script)) // Passing script to LuaUtils for state
+        globals.set("utils", LuaUtils(script)) // Passing script to LuaUtils for state
         globals.set("scheduler", LuaScheduler(this.plugin, script)) // Passing script to LuaScheduler for state
         globals.set("enums", LuaEnumWrapper())
         globals.set("import", LuaImport())

--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaUtils.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaUtils.kt
@@ -1,16 +1,15 @@
 package xyz.galaxyy.lualink.lua
 
-import com.github.only52607.luakt.CoerceKotlinToLua
 import org.bukkit.Bukkit
 import org.luaj.vm2.LuaTable
 import org.luaj.vm2.LuaValue
 import org.luaj.vm2.Varargs
 import org.luaj.vm2.lib.OneArgFunction
 import org.luaj.vm2.lib.VarArgFunction
-import xyz.galaxyy.lualink.LuaLink
 
-class LuaUtils(private val plugin: LuaLink, private val script: LuaScript) : LuaTable() {
+class LuaUtils(private val script: LuaScript) : LuaTable() {
     init {
+
         this.set("instanceOf", object: VarArgFunction() {
             override fun invoke(args: Varargs?): Varargs {
                 if (args == null || args.narg() != 2) {
@@ -32,137 +31,6 @@ class LuaUtils(private val plugin: LuaLink, private val script: LuaScript) : Lua
 
                 // Check if the object's class is assignable from the specified class
                 return LuaValue.valueOf(specifiedClass.isAssignableFrom(objClass))
-            }
-        })
-
-        this.set("runTask", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 1) {
-                    throw IllegalArgumentException("runTask expects 1 argument: callback")
-                }
-
-                val callback = args.arg(2).checkfunction()
-
-                val task = Bukkit.getScheduler().runTask(plugin, Runnable {
-                    callback.call()
-                })
-
-                script.tasks.add(task.taskId)
-
-                return CoerceKotlinToLua.coerce(task)
-            }
-        })
-
-        this.set("runTaskAsynchronously", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 2) {
-                    throw IllegalArgumentException("runTaskAsynchronously expects 1 argument: callback")
-                }
-
-                val callback = args.arg(1).checkfunction()
-
-                val task = Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
-                    callback.call()
-                })
-
-                script.tasks.add(task.taskId)
-
-                return CoerceKotlinToLua.coerce(task)
-            }
-        })
-
-        this.set("scheduleSyncDelayedTask", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 2) {
-                    throw IllegalArgumentException("scheduleSyncDelayedTask expects 2 arguments: callback, delay")
-                }
-
-                val callback = args.arg(1).checkfunction()
-                val delay = args.arg(2).checkint()
-
-                val task = Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, {
-                    callback.call()
-                }, delay.toLong())
-
-                script.tasks.add(task)
-
-                return LuaValue.valueOf(task)
-            }
-        })
-
-        this.set("scheduleSyncRepeatingTask", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 3) {
-                    throw IllegalArgumentException("scheduleSyncRepeatingTask expects 3 arguments: callback, delay, period")
-                }
-
-                val callback = args.arg(1).checkfunction()
-                val delay = args.arg(2).checkint()
-                val period = args.arg(3).checkint()
-
-                val task = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, {
-                    callback.call()
-                }, delay.toLong(), period.toLong())
-
-                script.tasks.add(task)
-
-                return LuaValue.valueOf(task)
-            }
-        })
-
-        this.set("runTaskAsynchronously", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 1) {
-                    throw IllegalArgumentException("runTaskAsynchronously expects 1 argument: callback")
-                }
-
-                val callback = args.arg(1).checkfunction()
-
-                val task = Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
-                    callback.call()
-                })
-
-                script.tasks.add(task.taskId)
-
-                return CoerceKotlinToLua.coerce(task)
-            }
-        })
-
-        this.set("runTaskLaterAsynchronously", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 2) {
-                    throw IllegalArgumentException("runTaskLaterAsynchronously expects 2 arguments: callback, delay")
-                }
-
-                val callback = args.arg(1).checkfunction()
-                val delay = args.arg(2).checkint()
-
-                val task = Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, Runnable  {
-                    callback.call()
-                }, delay.toLong())
-
-                script.tasks.add(task.taskId)
-
-                return CoerceKotlinToLua.coerce(task)
-            }
-        })
-
-        this.set("runTaskLater", object: VarArgFunction() {
-            override fun invoke(args: Varargs?): Varargs {
-                if (args == null || args.narg() != 2) {
-                    throw IllegalArgumentException("runTaskLater expects 2 arguments: callback, delay")
-                }
-
-                val callback = args.arg(1).checkfunction()
-                val delay = args.arg(2).checkint()
-
-                val task = Bukkit.getScheduler().runTaskLater(plugin, Runnable  {
-                    callback.call()
-                }, delay.toLong())
-
-                script.tasks.add(task.taskId)
-
-                return CoerceKotlinToLua.coerce(task)
             }
         })
 


### PR DESCRIPTION
I marked this PR as draft since I feel like these additions need to be discussed first. I also did not have enough time to test *everything*, but will definitely do that before marking as **ready-for-review**.

**Background:**
I felt like I could do some improvements to current scheduler implementation (#14) but since it relies on rather messy and inconsistent naming of `BukkitScheduler` methods, I decided to create a seperate one. There is also a few bugs in the current implementation, namely:
- `runTask` reads second argument but accepts only the first one. https://github.com/LuaLink/LuaLink/blob/9cbe08d24f4a8062eab137efcff8f54449c4c046/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaUtils.kt#L44
- `runTaskAsynchronously` is defined twice, where one of the definitions requires two arguments, but takes only one. https://github.com/LuaLink/LuaLink/blob/9cbe08d24f4a8062eab137efcff8f54449c4c046/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaUtils.kt#L58-L60

I didn't fix them as `LuaScheduler` is *supposed* to replace the **current** `LuaUtils`' scheduler.

<br />

**This PR aims to fix these bugs, and also:**
- Introduces more consistent and subjectively better naming.
- Exposes optional task parameter for tasks.
- Adds a way to schedule repeating asynchronous task.

<br />

Everything is subject to modifications, let me know what you want me to change.


