### PR TITLE
fix listeners for events that share the same handler list

### DIFF
--- a/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScript.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/lua/LuaScript.kt
@@ -101,7 +101,8 @@ class LuaScript(private val plugin: LuaLink, val file: File, val globals: Global
             val listener = object : Listener {}
 
             this.plugin.server.pluginManager.registerEvent(eventClass as Class<out org.bukkit.event.Event>, listener, EventPriority.NORMAL, { _, eventObj ->
-                callback.invoke(CoerceKotlinToLua.coerce(eventObj))
+                if (eventClass.isInstance(eventObj))
+                    callback.invoke(CoerceKotlinToLua.coerce(eventObj))
             }, this.plugin)
 
             this.listeners.add(listener)


### PR DESCRIPTION
I'm not sure what events are affected by this, but I was having issues with `BlockBreakEvent` and came across [this post](https://www.spigotmc.org/threads/furnaceextractevent-and-blockbreakevent.572624/).

Fix is based on [this reply](https://www.spigotmc.org/threads/furnaceextractevent-and-blockbreakevent.572624/#post-4477997) to the original post.