### PR TITLE
credentials support for user-specified libraries

### DIFF
--- a/docs/external_libraries.md
+++ b/docs/external_libraries.md
@@ -25,7 +25,14 @@ Starting from build [15](https://github.com/LuaLink/LuaLink/commit/65ce0ab517260
 {
     // Repositories to be used for dependency resolution.
     "repositories": {
-        "MavenCentral": "https://repo.maven.apache.org/maven2/"
+        // Repository definition using simple format.
+        "MavenCentral": "https://repo.maven.apache.org/maven2/",
+        // Repository definition with credentials authentication.
+        "SomePrivateRepository": {
+            "url": "https://repo.example.com/private",
+            "username": "RepositoryUsername",
+            "password": "SecretRepositoryPassword123"
+        }
     },
     // Dependencies to be downloaded and exposed to the scripting runtime.
     // Entries must be specified using Maven coordinate format: groupId:artifactId:version
@@ -35,6 +42,6 @@ Starting from build [15](https://github.com/LuaLink/LuaLink/commit/65ce0ab517260
 }
 ```
 
-In this example, we are adding stefvanschie's [IF](https://github.com/stefvanschie/IF) library of version `0.10.11` from [Maven Central](https://repo.maven.apache.org/maven2/) repository.
+In this example, we are adding stefvanschie's [IF](https://github.com/stefvanschie/IF) library of version `0.10.11` from [Maven Central](https://repo.maven.apache.org/maven2/) repository. You can also see how to add and authenticate with a private repository using credentials, which might be essential when working with closed-source projects or [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry).
 
-Now, after restarting the server, we should be able to import and access any class that belongs to this library.
+After restarting the server, we should be able to import and access any class that belongs to specified library(-ies).

--- a/src/main/java/xyz/galaxyy/lualink/PluginLibrariesLoader.java
+++ b/src/main/java/xyz/galaxyy/lualink/PluginLibrariesLoader.java
@@ -2,13 +2,24 @@ package xyz.galaxyy.lualink;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
 import io.papermc.paper.plugin.loader.PluginLoader;
 import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import org.apache.maven.model.Repository;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -16,15 +27,22 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Responsible for downloading and loading internal and user-specified libraries.
+ */
 @SuppressWarnings("UnstableApiUsage")
 public final class PluginLibrariesLoader implements PluginLoader {
 
-    private final Gson gson = new GsonBuilder().setLenient().create();
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(RepositoryInfo.class, RepositoryInfoDeserializer.INSTANCE)
+            .setLenient()
+            .create();
 
     @Override
     public void classloader(final @NotNull PluginClasspathBuilder classpathBuilder) {
@@ -38,7 +56,6 @@ public final class PluginLibrariesLoader implements PluginLoader {
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
-
         final File eLibrariesFile = new File(classpathBuilder.getContext().getDataDirectory().toFile(), "libraries.json");
         // Copying default file to "plugins/LuaLink/..."
         if (!eLibrariesFile.exists()) {
@@ -61,19 +78,69 @@ public final class PluginLibrariesLoader implements PluginLoader {
         }
     }
 
-    private record PluginLibraries(Map<String, String> repositories, List<String> dependencies) {
+    private record PluginLibraries(Map<String, RepositoryInfo> repositories, List<String> dependencies) {
 
         public MavenLibraryResolver toMavenLibraryResolver() {
             final MavenLibraryResolver resolver = new MavenLibraryResolver();
-            // ...
+            // Adding repositories to library resolver.
             repositories.entrySet().stream()
-                    .map(entry -> new RemoteRepository.Builder(entry.getKey(), "default", entry.getValue()).build())
+                    .map(entry -> {
+                        final RemoteRepository.Builder builder = new RemoteRepository.Builder(entry.getKey(), "default", entry.getValue().url);
+                        // Building and adding Authentication if specified.
+                        if (entry.getValue().username != null && entry.getValue().password != null)
+                            builder.setAuthentication(new AuthenticationBuilder().addUsername(entry.getValue().username).addPassword(entry.getValue().password).build());
+                        // Building and returning RemoteRepository object.
+                        return builder.build();
+                    })
                     .forEach(resolver::addRepository);
+            // Adding dependencies to library resolver.
             dependencies.stream()
                     .map(value -> new Dependency(new DefaultArtifact(value), null))
                     .forEach(resolver::addDependency);
-            // ...
+            // Returning library resolver instance.
             return resolver;
+        }
+    }
+
+    /**
+     * Holds information about maven repository.
+     */
+    private record RepositoryInfo(@NotNull String url, @Nullable String username, @Nullable String password) { /* DATA ONLY */ }
+
+    /**
+     * Converts JSON repository definition to {@link RepositoryInfo} object.
+     *
+     * <pre>{@code
+     * {
+     *     // Supports simple repository definition.
+     *     "SomeRepository": "https://repo.example.com/public",
+     *     // Supports username-password authentication.
+     *     "SomePrivateRepository": {
+     *         "url": "https://repo.example.com/private",
+     *         "username": "RepositoryUsername",
+     *         "password": "SecretRepositoryPassword123"
+     *     }
+     * }
+     * }</pre>
+     */
+    private static final class RepositoryInfoDeserializer implements JsonDeserializer<RepositoryInfo> {
+        // Singleton instance.
+        public static final RepositoryInfoDeserializer INSTANCE = new RepositoryInfoDeserializer();
+
+        @Override
+        public RepositoryInfo deserialize(final @NotNull JsonElement element, final @NotNull Type type, final @NotNull JsonDeserializationContext context) throws JsonParseException {
+            // Handling simple definitions, where value is url.
+            if (element instanceof JsonPrimitive)
+                return new RepositoryInfo(element.getAsString(), null, null);
+            // Handling more advanced definitions, where value is object containing url and (optionally) credentials.
+            if (element instanceof JsonObject object)
+                return new RepositoryInfo(
+                        object.get("url").getAsString(),
+                        object.has("username") ? object.get("username").getAsString() : null,
+                        object.has("password") ? object.get("password").getAsString() : null
+                );
+            // Throwing exception if unexpected/unsupported/invalid format has been provided.
+            throw new JsonParseException("Invalid repository format.");
         }
     }
 }

--- a/src/main/kotlin/xyz/galaxyy/lualink/commands/LuaLinkCommands.kt
+++ b/src/main/kotlin/xyz/galaxyy/lualink/commands/LuaLinkCommands.kt
@@ -9,6 +9,7 @@ import cloud.commandframework.annotations.suggestions.Suggestions
 import cloud.commandframework.context.CommandContext
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import org.luaj.vm2.lib.jse.JsePlatform
 import xyz.galaxyy.lualink.LuaLink
 import xyz.galaxyy.lualink.lua.LuaScript
 import xyz.galaxyy.lualink.lua.LuaScriptManager
@@ -75,6 +76,6 @@ class LuaLinkCommands(private val plugin: LuaLink, private val scriptManager: Lu
     @CommandMethod("lualink run <code>")
     @CommandPermission("lualink.scripts.run")
     fun runCode(sender: CommandSender, @Argument("code") @Greedy code: String) {
-        // TODO: Run code
+        JsePlatform.standardGlobals().load(code).eval()
     }
 }


### PR DESCRIPTION
Supports older, simple format as well as new, more detailed one. Tested with GitHub Packages Registry (as it requires authentication) and everything seems to work fine.

```jsonc
{
    // Supports simple repository definition.
    "SomeRepository": "https://repo.example.com/public",
    // Supports username-password authentication.
    "SomePrivateRepository": {
        "url": "https://repo.example.com/private",
        "username": "RepositoryUsername",
        "password": "SecretRepositoryPassword123"
    }
}
```